### PR TITLE
Add search switch and shadcn pagination

### DIFF
--- a/frontend/src/components/data-table-pagination.tsx
+++ b/frontend/src/components/data-table-pagination.tsx
@@ -1,4 +1,11 @@
-import { Button } from "@/components/ui/button";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination";
 import {
   Select,
   SelectContent,
@@ -7,7 +14,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Route } from "@/routes/jobs";
-import React from "react";
 
 interface DataTablePaginationProps {
   pageSize: number;
@@ -29,26 +35,8 @@ export function DataTablePagination({
       replace: true,
     });
 
-  // Local state for the page‐input field
-  const [pageInput, setPageInput] = React.useState<string>(String(page));
-
-  // Keep local input in sync when `page` changes externally
-  React.useEffect(() => {
-    setPageInput(String(page));
-  }, [page]);
-
-  // Handle when user commits a new page number
-  const commitPageChange = () => {
-    const parsed = Number(pageInput);
-    if (Number.isNaN(parsed) || parsed < 1) {
-      setPageInput(String(page));
-      return;
-    }
-    updateSearch(parsed, limit);
-  };
-
   return (
-    <div className="flex items-center justify-between py-4">
+    <div className="flex flex-col items-center justify-between gap-4 py-4 sm:flex-row">
       {/* Rows‐per‐page dropdown */}
       <div className="flex items-center space-x-2">
         <span className="text-sm">Rows per page:</span>
@@ -72,40 +60,62 @@ export function DataTablePagination({
         </Select>
       </div>
 
-      {/* Navigation buttons with page number between Prev and Next */}
-      <div className="flex items-center space-x-2">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => updateSearch(Math.max(1, page - 1), limit)}
-          disabled={page === 1}
-        >
-          ‹ Prev
-        </Button>
-
-        <input
-          type="number"
-          min={1}
-          className="page-input w-12 rounded border px-2 py-1 text-center text-sm"
-          value={pageInput}
-          onChange={(e) => setPageInput(e.target.value)}
-          onBlur={commitPageChange}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              e.currentTarget.blur();
-            }
-          }}
-        />
-
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => updateSearch(page + 1, limit)}
-          disabled={!hasMore}
-        >
-          Next ›
-        </Button>
-      </div>
+      {/* Pagination */}
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious
+              href="#"
+              onClick={(e) => {
+                e.preventDefault();
+                if (page > 1) updateSearch(page - 1, limit);
+              }}
+              className={page === 1 ? "pointer-events-none opacity-50" : ""}
+            />
+          </PaginationItem>
+          {page > 1 && (
+            <PaginationItem>
+              <PaginationLink
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  updateSearch(page - 1, limit);
+                }}
+              >
+                {page - 1}
+              </PaginationLink>
+            </PaginationItem>
+          )}
+          <PaginationItem>
+            <PaginationLink href="#" isActive>
+              {page}
+            </PaginationLink>
+          </PaginationItem>
+          {hasMore && (
+            <PaginationItem>
+              <PaginationLink
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  updateSearch(page + 1, limit);
+                }}
+              >
+                {page + 1}
+              </PaginationLink>
+            </PaginationItem>
+          )}
+          <PaginationItem>
+            <PaginationNext
+              href="#"
+              onClick={(e) => {
+                e.preventDefault();
+                if (hasMore) updateSearch(page + 1, limit);
+              }}
+              className={!hasMore ? "pointer-events-none opacity-50" : ""}
+            />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
     </div>
   );
 }

--- a/frontend/src/components/job-table.tsx
+++ b/frontend/src/components/job-table.tsx
@@ -13,14 +13,6 @@ import * as React from "react";
 import type { JobsGetJobsResponse } from "@/client";
 import { Button } from "@/components/ui/button";
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -28,6 +20,14 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 
 /** Build a ColumnDef<T> array from a “sample” row’s keys */
 function makeColumns(
@@ -70,7 +70,13 @@ function makeColumns(
                 <>
                   <Dialog open={open} onOpenChange={setOpen}>
                     <DialogTrigger asChild>
-                      <Button variant="link" size="sm" className="px-1 h-auto text-xs align-baseline">Read more</Button>
+                      <Button
+                        variant="link"
+                        size="sm"
+                        className="px-1 h-auto text-xs align-baseline"
+                      >
+                        Read more
+                      </Button>
                     </DialogTrigger>
                     <DialogContent className="sm:w-[90vw] sm:h-[80vh] w-[98vw] h-[90vh] max-w-3xl overflow-auto">
                       <DialogHeader>
@@ -144,7 +150,7 @@ export function JobTable({ data }: { data: JobsGetJobsResponse }) {
   });
 
   return (
-    <div className="rounded-md border">
+    <div className="rounded-md border overflow-x-auto">
       <Table>
         <TableHeader>
           {table.getHeaderGroups().map((hg) => (

--- a/frontend/src/components/ui/pagination.tsx
+++ b/frontend/src/components/ui/pagination.tsx
@@ -1,0 +1,91 @@
+import { cn } from "@/lib/utils";
+import * as React from "react";
+
+function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
+  return (
+    <nav
+      role="navigation"
+      aria-label="pagination"
+      className={cn("flex w-full justify-center", className)}
+      {...props}
+    />
+  );
+}
+
+function PaginationContent({
+  className,
+  ...props
+}: React.ComponentProps<"ul">) {
+  return <ul className={cn("flex items-center gap-1", className)} {...props} />;
+}
+
+function PaginationItem({ className, ...props }: React.ComponentProps<"li">) {
+  return <li className={cn("", className)} {...props} />;
+}
+
+interface PaginationLinkProps extends React.ComponentPropsWithoutRef<"a"> {
+  isActive?: boolean;
+}
+
+const PaginationLink = React.forwardRef<HTMLAnchorElement, PaginationLinkProps>(
+  ({ className, isActive, ...props }, ref) => (
+    <a
+      ref={ref}
+      aria-current={isActive ? "page" : undefined}
+      className={cn(
+        "inline-flex h-9 w-9 items-center justify-center rounded-md border border-slate-200 bg-white text-sm font-medium transition-colors hover:bg-slate-100 hover:text-slate-900 dark:border-slate-800 dark:bg-slate-950 dark:hover:bg-slate-800 dark:hover:text-slate-50",
+        isActive &&
+          "bg-slate-900 text-slate-50 hover:bg-slate-900 dark:bg-slate-50 dark:text-slate-900",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+PaginationLink.displayName = "PaginationLink";
+
+const PaginationPrevious = React.forwardRef<
+  HTMLAnchorElement,
+  React.ComponentPropsWithoutRef<"a">
+>(({ className, ...props }, ref) => (
+  <a
+    ref={ref}
+    className={cn(
+      "inline-flex h-9 w-9 items-center justify-center rounded-md border border-slate-200 bg-white text-sm font-medium hover:bg-slate-100 hover:text-slate-900 dark:border-slate-800 dark:bg-slate-950 dark:hover:bg-slate-800 dark:hover:text-slate-50",
+      className,
+    )}
+    {...props}
+  />
+));
+PaginationPrevious.displayName = "PaginationPrevious";
+
+const PaginationNext = React.forwardRef<
+  HTMLAnchorElement,
+  React.ComponentPropsWithoutRef<"a">
+>(({ className, ...props }, ref) => (
+  <a
+    ref={ref}
+    className={cn(
+      "inline-flex h-9 w-9 items-center justify-center rounded-md border border-slate-200 bg-white text-sm font-medium hover:bg-slate-100 hover:text-slate-900 dark:border-slate-800 dark:bg-slate-950 dark:hover:bg-slate-800 dark:hover:text-slate-50",
+      className,
+    )}
+    {...props}
+  />
+));
+PaginationNext.displayName = "PaginationNext";
+
+function PaginationEllipsis() {
+  return (
+    <span className="inline-flex h-9 w-9 items-center justify-center">…</span>
+  );
+}
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationPrevious,
+  PaginationNext,
+  PaginationEllipsis,
+};

--- a/frontend/src/components/ui/switch.tsx
+++ b/frontend/src/components/ui/switch.tsx
@@ -1,0 +1,22 @@
+import { cn } from "@/lib/utils";
+import * as SwitchPrimitive from "@radix-ui/react-switch";
+import * as React from "react";
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-slate-900 data-[state=unchecked]:bg-slate-200 dark:data-[state=checked]:bg-slate-50 dark:data-[state=unchecked]:bg-slate-700",
+      className,
+    )}
+    {...props}
+  >
+    <SwitchPrimitive.Thumb className="pointer-events-none block h-4 w-4 rounded-full bg-white shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0" />
+  </SwitchPrimitive.Root>
+));
+Switch.displayName = SwitchPrimitive.Root.displayName;
+
+export { Switch };

--- a/frontend/src/routes/jobs.tsx
+++ b/frontend/src/routes/jobs.tsx
@@ -3,15 +3,16 @@ import { Suspense } from "react";
 import { z } from "zod";
 
 import { DataTablePagination } from "@/components/data-table-pagination";
-import { JobSearchForm } from "@/components/job-search-form";
 import { AdvancedSearchForm } from "@/components/job-advanced-search-form";
+import { JobSearchForm } from "@/components/job-search-form";
+import { Button } from "@/components/ui/button";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
-import { ChevronsUpDown } from "lucide-react"
-import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { ChevronsUpDown } from "lucide-react";
 
 import { JobTable } from "@/components/job-table";
 import { JobTableSkeleton } from "@/components/job-table-skeleton";
@@ -27,6 +28,7 @@ export const Route = createFileRoute("/jobs")({
     company: z.array(z.string()).catch([]),
     location: z.array(z.string()).catch([]),
     description: z.array(z.string()).catch([]),
+    advanced: z.coerce.boolean().default(false),
   }),
   component: JobsPage,
 });
@@ -39,44 +41,71 @@ export type SearchValues = {
 };
 
 function JobsPage() {
-  const { limit } = Route.useSearch();
+  const { limit, advanced } = Route.useSearch();
   const navigate = Route.useNavigate();
 
   // When user searches, reset page back to 1
   const handleSearch = (val: string) =>
     navigate({
       to: ".",
-      search: { page: 1, limit, q: val },
+      search: { page: 1, limit, q: val, advanced: false },
       replace: true,
-  });
+    });
 
   const handleAdvancedSearch = (val: SearchValues) =>
     navigate({
       to: ".",
-      search: { page: 1, limit, ...val },
+      search: { page: 1, limit, advanced: true, ...val },
       replace: true,
     });
 
   return (
     <div className="mx-auto flex max-w-6xl flex-col gap-4 p-4">
-      <JobSearchForm onSubmit={handleSearch} />
+      <div className="flex items-center gap-2">
+        <Switch
+          id="mode"
+          checked={advanced}
+          onCheckedChange={(checked) =>
+            navigate({
+              to: ".",
+              search: { ...Route.useSearch(), advanced: checked, page: 1 },
+              replace: true,
+            })
+          }
+        />
+        <label
+          htmlFor="mode"
+          className="text-sm font-semibold text-muted-foreground cursor-pointer"
+        >
+          {advanced ? "Advanced Search" : "Basic Search"}
+        </label>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        {advanced
+          ? "Specify keywords for title, company, location and description."
+          : "Search across title, company, location and description."}
+      </p>
 
-      <Collapsible>
-        <CollapsibleTrigger asChild>
-          <Button variant="ghost" size="icon" className="size-8">
-            <ChevronsUpDown />
-            <span className="sr-only">Toggle</span>
-          </Button>
-        </CollapsibleTrigger>
-        <span className="text-sm font-semibold text-muted-foreground">
-          Advanced Search
-        </span>
-        <CollapsibleContent className="mt-2">
-          <AdvancedSearchForm 
-            onSubmit={handleAdvancedSearch} 
-          />
-        </CollapsibleContent>
-      </Collapsible>
+      {advanced ? (
+        <Collapsible>
+          <CollapsibleTrigger asChild>
+            <div className="flex items-center gap-2 cursor-pointer">
+              <Button variant="ghost" size="icon" className="size-8">
+                <ChevronsUpDown />
+                <span className="sr-only">Toggle</span>
+              </Button>
+              <span className="text-sm font-semibold text-muted-foreground">
+                Advanced Fields
+              </span>
+            </div>
+          </CollapsibleTrigger>
+          <CollapsibleContent className="mt-2">
+            <AdvancedSearchForm onSubmit={handleAdvancedSearch} />
+          </CollapsibleContent>
+        </Collapsible>
+      ) : (
+        <JobSearchForm onSubmit={handleSearch} />
+      )}
 
       {/* Only table + pagination will suspend */}
       <Suspense fallback={<JobTableSkeleton />}>


### PR DESCRIPTION
## Summary
- add Switch and Pagination components from Shadcn
- refactor jobs page to toggle basic/advanced search
- update pagination UI to Shadcn component
- make job table horizontally scrollable on mobile

## Testing
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685d3b732d5883218d669db08691ec7e