### PR TITLE
Add user accounts and search history

### DIFF
--- a/backend/earlycareers/api.py
+++ b/backend/earlycareers/api.py
@@ -2,13 +2,24 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, HTTPException, Query, status
 
 from earlycareers import crud
-from earlycareers.deps import SessionDep  # noqa: TC001
-from earlycareers.schemas import JobRead
+from earlycareers.core import security
+from earlycareers.deps import CurrentUser, SessionDep  # noqa: TC001
+from earlycareers.models import SearchHistory, User
+from earlycareers.schemas import (  # noqa: TC001
+    BodyAuthLogin,
+    HistoryCreate,
+    HistoryRead,
+    JobRead,
+    Token,
+    UserCreate,
+    UserRead,
+)
 
 if TYPE_CHECKING:
+    from earlycareers import schemas
     from earlycareers.models import Job
 
 router = APIRouter()
@@ -50,3 +61,70 @@ def get_jobs_advanced(
         location=location,
         description=description,
     )
+
+
+@router.post("/auth/signup", response_model=UserRead, tags=["auth"], status_code=201)
+def signup(*, session: SessionDep, user_in: UserCreate) -> UserRead:
+    hashed = security.get_password_hash(user_in.password)
+    user = User(**user_in.model_dump(exclude={"password"}), hashed_password=hashed)
+    return crud.create_user(session=session, user=user)
+
+
+@router.post("/auth/login", response_model=Token, tags=["auth"])
+def login(*, session: SessionDep, data: BodyAuthLogin) -> Token:
+    user = crud.authenticate(
+        session=session, username=data.username, password=data.password
+    )
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials"
+        )
+    token = security.create_access_token(user.id)
+    return Token(access_token=token)
+
+
+@router.get("/users/me", response_model=UserRead, tags=["users"])
+def get_me(current_user: CurrentUser) -> UserRead:
+    return current_user
+
+
+@router.patch("/users/me", response_model=UserRead, tags=["users"])
+def update_me(
+    *, session: SessionDep, current_user: CurrentUser, user_in: schemas.UserUpdate
+) -> UserRead:
+    return crud.update_user(session=session, user=current_user, user_in=user_in)
+
+
+@router.post("/users/me/change-password", status_code=204, tags=["users"])
+def change_password(
+    *,
+    session: SessionDep,
+    current_user: CurrentUser,
+    data: schemas.ChangePassword,
+) -> None:
+    try:
+        crud.change_password(
+            session=session,
+            user=current_user,
+            old_password=data.old_password,
+            new_password=data.new_password,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST) from exc
+
+
+@router.post(
+    "/search-history", response_model=HistoryRead, tags=["history"], status_code=201
+)
+def add_history(
+    *, session: SessionDep, current_user: CurrentUser, history: HistoryCreate
+) -> HistoryRead:
+    record = SearchHistory(user_id=current_user.id, query=history.query)
+    return crud.create_history(session=session, history=record)
+
+
+@router.get("/search-history", response_model=list[HistoryRead], tags=["history"])
+def list_history(
+    *, session: SessionDep, current_user: CurrentUser
+) -> list[HistoryRead]:
+    return crud.get_history(session=session, user_id=current_user.id)

--- a/backend/earlycareers/core/config.py
+++ b/backend/earlycareers/core/config.py
@@ -26,6 +26,9 @@ class Settings(BaseSettings):
 
     DB_URI: PostgresDsn
 
+    SECRET_KEY: str = "CHANGE_ME"  # noqa: S105
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 60
+
     @computed_field
     @property
     def all_cors_origins(self) -> list[str]:

--- a/backend/earlycareers/core/database.py
+++ b/backend/earlycareers/core/database.py
@@ -1,7 +1,7 @@
 from sqlmodel import SQLModel, create_engine
 
 from earlycareers.core.config import settings
-from earlycareers.models import Job  # noqa: F401
+from earlycareers.models import Job, SearchHistory, User  # noqa: F401
 
 engine = create_engine(str(settings.DB_URI), echo=True)
 

--- a/backend/earlycareers/core/security.py
+++ b/backend/earlycareers/core/security.py
@@ -1,0 +1,38 @@
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import bcrypt
+import jwt
+
+from earlycareers.core.config import settings
+
+ALGORITHM = "HS256"
+
+
+def create_access_token(
+    subject: uuid.UUID, expires_delta: timedelta | None = None
+) -> str:
+    if expires_delta is None:
+        expires_delta = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    expire = datetime.now(UTC) + expires_delta
+    to_encode: dict[str, datetime | str] = {
+        "exp": expire,
+        "sub": str(subject),
+    }
+    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=ALGORITHM)
+
+
+def verify_password(plain_password: str | bytes, hashed_password: str | bytes) -> bool:
+    if isinstance(plain_password, str):
+        plain_password = plain_password.encode()
+    if isinstance(hashed_password, str):
+        hashed_password = hashed_password.encode()
+
+    return bcrypt.checkpw(plain_password, hashed_password)
+
+
+def get_password_hash(plain_password: str | bytes) -> str:
+    if isinstance(plain_password, str):
+        plain_password = plain_password.encode()
+
+    return bcrypt.hashpw(plain_password, bcrypt.gensalt()).decode()

--- a/backend/earlycareers/deps.py
+++ b/backend/earlycareers/deps.py
@@ -1,10 +1,15 @@
+import uuid
 from collections.abc import Generator
 from typing import Annotated
 
-from fastapi import Depends
+import jwt
+from fastapi import Depends, Header, HTTPException, status
 from sqlmodel import Session
 
+from earlycareers.core.config import settings
 from earlycareers.core.database import engine
+from earlycareers.core.security import ALGORITHM
+from earlycareers.models import User
 
 
 def get_session() -> Generator[Session]:
@@ -13,3 +18,23 @@ def get_session() -> Generator[Session]:
 
 
 SessionDep = Annotated[Session, Depends(get_session)]
+
+
+def get_current_user(
+    session: SessionDep, authorization: str | None = Header(default=None)
+) -> User:
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    token = authorization.removeprefix("Bearer ").strip()
+    try:
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[ALGORITHM])
+    except jwt.PyJWTError as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED) from exc
+    user_id = uuid.UUID(str(payload.get("sub")))
+    user = session.get(User, user_id)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    return user
+
+
+CurrentUser = Annotated[User, Depends(get_current_user)]

--- a/backend/earlycareers/models.py
+++ b/backend/earlycareers/models.py
@@ -1,3 +1,6 @@
+import uuid
+from datetime import UTC, date, datetime
+
 from sqlmodel import Field, SQLModel
 
 
@@ -15,3 +18,31 @@ class JobBase(SQLModel):
 
 class Job(JobBase, table=True):
     __tablename__ = "jobs"  # pyright: ignore
+
+
+class UUIDBase(SQLModel):
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+
+
+class UserBase(SQLModel):
+    username: str = Field(unique=True, nullable=False, index=True)
+    name: str | None = None
+    surname: str | None = None
+    birthdate: date | None = None
+    email: str | None = None
+
+
+class User(UUIDBase, UserBase, table=True):
+    __tablename__ = "users"  # pyright: ignore[assignment-type]
+
+    hashed_password: str = Field(nullable=False, index=True)
+
+
+class SearchHistory(UUIDBase, table=True):
+    __tablename__ = "search_history"  # pyright: ignore[assignment-type]
+
+    user_id: uuid.UUID = Field(foreign_key="users.id", nullable=False, index=True)
+    query: str = Field(nullable=False)
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC), nullable=False
+    )

--- a/backend/earlycareers/schemas.py
+++ b/backend/earlycareers/schemas.py
@@ -1,5 +1,49 @@
-from .models import JobBase
+import uuid
+from datetime import date, datetime
+
+from sqlmodel import SQLModel
+
+from .models import JobBase, UserBase, UUIDBase
 
 
 class JobRead(JobBase):
     pass
+
+
+class Token(SQLModel):
+    access_token: str
+
+
+class UserCreate(UserBase):
+    password: str
+
+
+class BodyAuthLogin(SQLModel):
+    username: str
+    password: str
+
+
+class UserRead(UserBase, UUIDBase):
+    pass
+
+
+class UserUpdate(SQLModel):
+    username: str | None = None
+    name: str | None = None
+    surname: str | None = None
+    birthdate: date | None = None
+    email: str | None = None
+
+
+class ChangePassword(SQLModel):
+    old_password: str
+    new_password: str
+
+
+class HistoryCreate(SQLModel):
+    query: str
+
+
+class HistoryRead(HistoryCreate, UUIDBase):
+    user_id: uuid.UUID
+    created_at: datetime

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -9,6 +9,8 @@ dependencies = [
     "requests>=2.32.3",
     "sqlalchemy>=2.0.41",
     "sqlmodel>=0.0.24",
+    "bcrypt>=4.1.2",
+    "pyjwt>=2.8.0",
 ]
 
 

--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -1,9 +1,21 @@
 import logo from "@/static/logo.png";
+import { Link } from "@tanstack/react-router";
+import useAuth from "@/hooks/use-auth";
+import { Button } from "@/components/ui/button";
+import { UserMenu } from "@/components/user-menu";
 
 export function Header() {
+  const { user, logout } = useAuth();
   return (
-    <header className="w-full flex justify-center items-center py-4 border-b bg-white dark:bg-slate-950">
+    <header className="w-full flex items-center justify-between py-4 border-b bg-white dark:bg-slate-950 px-4">
       <img src={logo} alt="Logo" className="h-10" />
+      {user ? (
+        <UserMenu onLogout={logout} />
+      ) : (
+        <Button asChild variant="outline">
+          <Link to="/login">Login</Link>
+        </Button>
+      )}
     </header>
   );
 }

--- a/frontend/src/components/login-form.tsx
+++ b/frontend/src/components/login-form.tsx
@@ -1,0 +1,79 @@
+import { SubmitHandler, UseFormReturn } from "react-hook-form";
+import { PasswordInput } from "@/components/password-input";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+export type LoginFormData = {
+  username: string;
+  password: string;
+};
+
+export type LoginFormProps = React.ComponentPropsWithoutRef<"div"> & {
+  form: UseFormReturn<LoginFormData>;
+  onFormSubmit: SubmitHandler<LoginFormData>;
+};
+
+export function LoginForm({
+  className,
+  form,
+  onFormSubmit,
+  ...props
+}: LoginFormProps) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = form;
+  return (
+    <div className={cn("flex flex-col gap-6", className)} {...props}>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-2xl">Login</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit(onFormSubmit)}>
+            <div className="flex flex-col gap-6">
+              <div className="grid gap-2">
+                <Label htmlFor="username">Username</Label>
+                <Input
+                  id="username"
+                  type="text"
+                  {...register("username", {
+                    required: "Username is required",
+                  })}
+                />
+                {errors.username && (
+                  <p className="text-sm text-red-500">
+                    {errors.username.message}
+                  </p>
+                )}
+              </div>
+              <div className="grid gap-2">
+                <div className="flex items-center">
+                  <Label htmlFor="password">Password</Label>
+                </div>
+                <PasswordInput
+                  id="password"
+                  {...register("password", {
+                    required: "Password is required",
+                  })}
+                />
+                {errors.password && (
+                  <p className="text-sm text-red-500">
+                    {errors.password.message}
+                  </p>
+                )}
+              </div>
+              <Button type="submit" className="w-full">
+                Login
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/password-input.tsx
+++ b/frontend/src/components/password-input.tsx
@@ -1,0 +1,44 @@
+import { EyeIcon, EyeOffIcon } from "lucide-react";
+import React, { forwardRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+const PasswordInput = forwardRef<
+  HTMLInputElement,
+  React.ComponentPropsWithoutRef<"input">
+>(({ className, ...props }, ref) => {
+  const [showPassword, setShowPassword] = useState(false);
+
+  return (
+    <div className="relative">
+      <Input
+        type={showPassword ? "text" : "password"}
+        className={cn("hide-password-toggle pr-10", className)}
+        ref={ref}
+        {...props}
+      />
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+        onClick={() => setShowPassword((prev) => !prev)}
+      >
+        {showPassword ? (
+          <EyeOffIcon className="h-4 w-4" aria-hidden="true" />
+        ) : (
+          <EyeIcon className="h-4 w-4" aria-hidden="true" />
+        )}
+        <span className="sr-only">
+          {showPassword ? "Hide password" : "Show password"}
+        </span>
+      </Button>{" "}
+      <style>{`.hide-password-toggle::-ms-reveal,.hide-password-toggle::-ms-clear {visibility: hidden;pointer-events: none; display: none;}`}</style>
+    </div>
+  );
+});
+
+PasswordInput.displayName = "PasswordInput";
+export { PasswordInput };

--- a/frontend/src/components/signup-form.tsx
+++ b/frontend/src/components/signup-form.tsx
@@ -1,0 +1,87 @@
+import { SubmitHandler, UseFormReturn } from "react-hook-form";
+import { PasswordInput } from "@/components/password-input";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+export type SignupFormData = {
+  username: string;
+  password: string;
+  name?: string;
+  surname?: string;
+  birthdate?: string;
+  email?: string;
+};
+
+export type SignupFormProps = React.ComponentPropsWithoutRef<"div"> & {
+  form: UseFormReturn<SignupFormData>;
+  onFormSubmit: SubmitHandler<SignupFormData>;
+};
+
+export function SignupForm({
+  className,
+  form,
+  onFormSubmit,
+  ...props
+}: SignupFormProps) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = form;
+  return (
+    <div className={cn("flex flex-col gap-6", className)} {...props}>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-2xl">Sign Up</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit(onFormSubmit)} className="flex flex-col gap-6">
+            <div className="grid gap-2">
+              <Label htmlFor="username">Username</Label>
+              <Input
+                id="username"
+                type="text"
+                {...register("username", { required: "Username is required" })}
+              />
+              {errors.username && (
+                <p className="text-sm text-red-500">{errors.username.message}</p>
+              )}
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="password">Password</Label>
+              <PasswordInput
+                id="password"
+                {...register("password", { required: "Password is required" })}
+              />
+              {errors.password && (
+                <p className="text-sm text-red-500">{errors.password.message}</p>
+              )}
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="name">Name</Label>
+              <Input id="name" type="text" {...register("name")} />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="surname">Surname</Label>
+              <Input id="surname" type="text" {...register("surname")} />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="birthdate">Birthdate</Label>
+              <Input id="birthdate" type="date" {...register("birthdate")} />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="email">Email</Label>
+              <Input id="email" type="email" {...register("email")} />
+            </div>
+            <Button type="submit" className="w-full">
+              Sign Up
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/user-menu.tsx
+++ b/frontend/src/components/user-menu.tsx
@@ -1,0 +1,49 @@
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { UserIcon } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export function UserMenu({ onLogout }: { onLogout: () => void }) {
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <Button variant="ghost" size="icon">
+          <UserIcon className="h-5 w-5" />
+        </Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          sideOffset={4}
+          className={cn(
+            "z-50 min-w-32 rounded-md border bg-white p-1 text-sm shadow-md dark:bg-slate-950"
+          )}
+        >
+          <DropdownMenu.Item asChild>
+            <Link
+              to="/history"
+              className="block cursor-pointer select-none rounded-sm px-2 py-1 focus:bg-slate-100 dark:focus:bg-slate-800"
+            >
+              History
+            </Link>
+          </DropdownMenu.Item>
+          <DropdownMenu.Item asChild>
+            <Link
+              to="/settings"
+              className="block cursor-pointer select-none rounded-sm px-2 py-1 focus:bg-slate-100 dark:focus:bg-slate-800"
+            >
+              Settings
+            </Link>
+          </DropdownMenu.Item>
+          <DropdownMenu.Separator className="my-1 h-px bg-slate-100 dark:bg-slate-800" />
+          <DropdownMenu.Item
+            onSelect={onLogout}
+            className="cursor-pointer select-none rounded-sm px-2 py-1 focus:bg-slate-100 dark:focus:bg-slate-800"
+          >
+            Logout
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+}

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -1,0 +1,121 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
+import type { BodyAuthLogin, UserRead } from "@/client/types.gen";
+import { useToast } from "@/hooks/use-toast";
+
+const isLoggedIn = () => {
+  return localStorage.getItem("access_token") !== null;
+};
+
+const useAuth = () => {
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const { data: user, isLoading } = useQuery<UserRead | null, Error>({
+    queryKey: ["currentUser"],
+    queryFn: async () => {
+      const res = await fetch(
+        `${import.meta.env.VITE_API_BASE_URL}/users/me`,
+        {
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem("access_token")}`,
+          },
+        },
+      );
+      if (!res.ok) {
+        throw new Error(await res.text());
+      }
+      return (await res.json()) as UserRead;
+    },
+    enabled: isLoggedIn(),
+  });
+
+  type SignupData = {
+    username: string;
+    password: string;
+    name?: string;
+    surname?: string;
+    birthdate?: string;
+    email?: string;
+  };
+
+  const signup = async (data: SignupData) => {
+    const res = await fetch(`${import.meta.env.VITE_API_BASE_URL}/auth/signup`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) {
+      throw new Error(await res.text());
+    }
+    await login({ username: data.username, password: data.password });
+  };
+
+  const login = async (data: BodyAuthLogin) => {
+    const res = await fetch(`${import.meta.env.VITE_API_BASE_URL}/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) {
+      throw new Error(await res.text());
+    }
+    const json = (await res.json()) as { access_token: string };
+    localStorage.setItem("access_token", json.access_token);
+  };
+
+  const loginMutation = useMutation({
+    mutationFn: login,
+    onSuccess: () => {
+      toast({
+        description: "Login successful",
+        variant: "success",
+      });
+      navigate({ to: "/" });
+    },
+    onError: async (err: Object) => {
+      const error = (err as any)?.detail ?? "Something went wrong";
+      toast({
+        description: error,
+        variant: "destructive",
+      });
+      setError(error);
+    },
+  });
+
+  const signupMutation = useMutation({
+    mutationFn: signup,
+    onSuccess: () => {
+      toast({ description: "Signup successful", variant: "success" });
+      navigate({ to: "/" });
+    },
+    onError: async (err: Object) => {
+      const error = (err as any)?.detail ?? "Something went wrong";
+      toast({ description: error, variant: "destructive" });
+      setError(error);
+    },
+  });
+
+  const logout = () => {
+    localStorage.removeItem("access_token");
+    toast({
+      description: "Logout successful",
+      variant: "success",
+    });
+    navigate({ to: "/login" });
+  };
+
+  return {
+    loginMutation,
+    signupMutation,
+    logout,
+    user,
+    isLoading,
+    error,
+    resetError: () => setError(null),
+  };
+};
+
+export { isLoggedIn };
+export default useAuth;

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -13,12 +13,40 @@
 import { Route as rootRoute } from "./routes/__root";
 import { Route as LayoutIndexImport } from "./routes/_layout/index";
 import { Route as JobsImport } from "./routes/jobs";
+import { Route as LoginImport } from "./routes/login";
+import { Route as SignupImport } from "./routes/signup";
+import { Route as SettingsImport } from "./routes/settings";
+import { Route as HistoryImport } from "./routes/history";
 
 // Create/Update Routes
 
 const JobsRoute = JobsImport.update({
   id: "/jobs",
   path: "/jobs",
+  getParentRoute: () => rootRoute,
+} as any);
+
+const LoginRoute = LoginImport.update({
+  id: "/login",
+  path: "/login",
+  getParentRoute: () => rootRoute,
+} as any);
+
+const SignupRoute = SignupImport.update({
+  id: "/signup",
+  path: "/signup",
+  getParentRoute: () => rootRoute,
+} as any);
+
+const SettingsRoute = SettingsImport.update({
+  id: "/settings",
+  path: "/settings",
+  getParentRoute: () => rootRoute,
+} as any);
+
+const HistoryRoute = HistoryImport.update({
+  id: "/history",
+  path: "/history",
   getParentRoute: () => rootRoute,
 } as any);
 
@@ -39,6 +67,34 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof JobsImport;
       parentRoute: typeof rootRoute;
     };
+    "/login": {
+      id: "/login";
+      path: "/login";
+      fullPath: "/login";
+      preLoaderRoute: typeof LoginImport;
+      parentRoute: typeof rootRoute;
+    };
+    "/signup": {
+      id: "/signup";
+      path: "/signup";
+      fullPath: "/signup";
+      preLoaderRoute: typeof SignupImport;
+      parentRoute: typeof rootRoute;
+    };
+    "/settings": {
+      id: "/settings";
+      path: "/settings";
+      fullPath: "/settings";
+      preLoaderRoute: typeof SettingsImport;
+      parentRoute: typeof rootRoute;
+    };
+    "/history": {
+      id: "/history";
+      path: "/history";
+      fullPath: "/history";
+      preLoaderRoute: typeof HistoryImport;
+      parentRoute: typeof rootRoute;
+    };
     "/_layout/": {
       id: "/_layout/";
       path: "/";
@@ -53,26 +109,45 @@ declare module "@tanstack/react-router" {
 
 export interface FileRoutesByFullPath {
   "/jobs": typeof JobsRoute;
+  "/login": typeof LoginRoute;
+  "/signup": typeof SignupRoute;
+  "/settings": typeof SettingsRoute;
+  "/history": typeof HistoryRoute;
   "/": typeof LayoutIndexRoute;
 }
 
 export interface FileRoutesByTo {
   "/jobs": typeof JobsRoute;
+  "/login": typeof LoginRoute;
+  "/signup": typeof SignupRoute;
+  "/settings": typeof SettingsRoute;
+  "/history": typeof HistoryRoute;
   "/": typeof LayoutIndexRoute;
 }
 
 export interface FileRoutesById {
   __root__: typeof rootRoute;
   "/jobs": typeof JobsRoute;
+  "/login": typeof LoginRoute;
+  "/signup": typeof SignupRoute;
+  "/settings": typeof SettingsRoute;
+  "/history": typeof HistoryRoute;
   "/_layout/": typeof LayoutIndexRoute;
 }
 
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath;
-  fullPaths: "/jobs" | "/";
+  fullPaths: "/jobs" | "/login" | "/signup" | "/settings" | "/history" | "/";
   fileRoutesByTo: FileRoutesByTo;
-  to: "/jobs" | "/";
-  id: "__root__" | "/jobs" | "/_layout/";
+  to: "/jobs" | "/login" | "/signup" | "/settings" | "/history" | "/";
+  id:
+    | "__root__"
+    | "/jobs"
+    | "/login"
+    | "/signup"
+    | "/settings"
+    | "/history"
+    | "/_layout/";
   fileRoutesById: FileRoutesById;
 }
 
@@ -80,12 +155,20 @@ export interface RootRouteChildren {
   JobsRoute: typeof JobsRoute;
   AdvancedRoute: typeof AdvancedRoute;
   LayoutIndexRoute: typeof LayoutIndexRoute;
+  LoginRoute: typeof LoginRoute;
+  SignupRoute: typeof SignupRoute;
+  SettingsRoute: typeof SettingsRoute;
+  HistoryRoute: typeof HistoryRoute;
 }
 
 const rootRouteChildren: RootRouteChildren = {
   JobsRoute: JobsRoute,
   AdvancedRoute: AdvancedRoute,
   LayoutIndexRoute: LayoutIndexRoute,
+  LoginRoute: LoginRoute,
+  SignupRoute: SignupRoute,
+  SettingsRoute: SettingsRoute,
+  HistoryRoute: HistoryRoute,
 };
 
 export const routeTree = rootRoute
@@ -99,11 +182,27 @@ export const routeTree = rootRoute
       "filePath": "__root.tsx",
       "children": [
         "/jobs",
-        "/_layout/"
+        "/_layout/",
+        "/login",
+        "/signup",
+        "/settings",
+        "/history"
       ]
     },
     "/jobs": {
       "filePath": "jobs.tsx"
+    },
+    "/login": {
+      "filePath": "login.tsx"
+    },
+    "/signup": {
+      "filePath": "signup.tsx"
+    },
+    "/settings": {
+      "filePath": "settings.tsx"
+    },
+    "/history": {
+      "filePath": "history.tsx"
     },
     "/_layout/": {
       "filePath": "_layout/index.tsx"

--- a/frontend/src/routes/history.tsx
+++ b/frontend/src/routes/history.tsx
@@ -1,0 +1,43 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import useAuth, { isLoggedIn } from "@/hooks/use-auth";
+import { useQuery } from "@tanstack/react-query";
+
+export const Route = createFileRoute("/history")({
+  component: History,
+  beforeLoad: () => {
+    if (!isLoggedIn()) {
+      throw redirect({ to: "/login" });
+    }
+  },
+});
+
+function History() {
+  const { user } = useAuth();
+  const { data } = useQuery({
+    queryKey: ["history"],
+    queryFn: async () => {
+      const res = await fetch(`${import.meta.env.VITE_API_BASE_URL}/search-history`, {
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem("access_token")}`,
+        },
+      });
+      if (!res.ok) throw new Error();
+      return (await res.json()) as Array<{ id: string; query: string; created_at: string }>;
+    },
+    enabled: !!user,
+  });
+
+  return (
+    <div className="mx-auto max-w-2xl p-6">
+      <h1 className="mb-4 text-2xl font-semibold">Search History</h1>
+      <ul className="space-y-2">
+        {data?.map((h) => (
+          <li key={h.id} className="border-b pb-2 last:border-b-0">
+            <span className="font-medium">{h.query}</span>
+            <span className="ml-2 text-xs text-slate-500">{new Date(h.created_at).toLocaleString()}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -1,0 +1,44 @@
+import { createFileRoute, redirect, Link } from "@tanstack/react-router";
+import { type SubmitHandler, useForm } from "react-hook-form";
+import type { BodyAuthLogin } from "@/client";
+import { LoginForm } from "@/components/login-form";
+import useAuth, { isLoggedIn } from "@/hooks/use-auth";
+
+export const Route = createFileRoute("/login")({
+  component: Login,
+  beforeLoad: () => {
+    if (isLoggedIn()) {
+      throw redirect({ to: "/" });
+    }
+  },
+});
+
+function Login() {
+  const { loginMutation, resetError } = useAuth();
+
+  const form = useForm<BodyAuthLogin>({
+    defaultValues: { username: "", password: "" },
+    mode: "onSubmit",
+    criteriaMode: "all",
+  });
+
+  const onSubmit: SubmitHandler<BodyAuthLogin> = async (data: BodyAuthLogin) => {
+    resetError();
+    try {
+      await loginMutation.mutateAsync(data);
+    } catch {
+      // error is handled by useAuth hook
+    }
+  };
+
+  return (
+    <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
+      <div className="w-full max-w-sm space-y-4">
+        <LoginForm form={form} onFormSubmit={onSubmit} />
+        <p className="text-center text-sm">
+          Don't have an account? <Link to="/signup" className="underline">Sign up</Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/routes/settings.tsx
+++ b/frontend/src/routes/settings.tsx
@@ -1,0 +1,91 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { useForm, type SubmitHandler } from "react-hook-form";
+import { useQueryClient } from "@tanstack/react-query";
+import useAuth, { isLoggedIn } from "@/hooks/use-auth";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { PasswordInput } from "@/components/password-input";
+
+export const Route = createFileRoute("/settings")({
+  component: Settings,
+  beforeLoad: () => {
+    if (!isLoggedIn()) {
+      throw redirect({ to: "/login" });
+    }
+  },
+});
+
+function Settings() {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+  const profileForm = useForm({
+    defaultValues: {
+      name: user?.name ?? "",
+      surname: user?.surname ?? "",
+      birthdate: user?.birthdate ?? "",
+      email: user?.email ?? "",
+    },
+  });
+
+  const passwordForm = useForm({ defaultValues: { old_password: "", new_password: "" } });
+
+  const onUpdateProfile: SubmitHandler<typeof profileForm.getValues()> = async (data) => {
+    await fetch(`${import.meta.env.VITE_API_BASE_URL}/users/me`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${localStorage.getItem("access_token")}`,
+      },
+      body: JSON.stringify(data),
+    });
+    queryClient.invalidateQueries({ queryKey: ["currentUser"] });
+  };
+
+  const onChangePassword: SubmitHandler<typeof passwordForm.getValues()> = async (data) => {
+    await fetch(`${import.meta.env.VITE_API_BASE_URL}/users/me/change-password`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${localStorage.getItem("access_token")}`,
+      },
+      body: JSON.stringify(data),
+    });
+    passwordForm.reset();
+  };
+
+  return (
+    <div className="mx-auto max-w-xl space-y-8 p-6">
+      <form onSubmit={profileForm.handleSubmit(onUpdateProfile)} className="space-y-4">
+        <div className="grid gap-2">
+          <Label htmlFor="name">Name</Label>
+          <Input id="name" {...profileForm.register("name")} />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor="surname">Surname</Label>
+          <Input id="surname" {...profileForm.register("surname")} />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor="birthdate">Birthdate</Label>
+          <Input id="birthdate" type="date" {...profileForm.register("birthdate")} />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor="email">Email</Label>
+          <Input id="email" type="email" {...profileForm.register("email")} />
+        </div>
+        <Button type="submit">Save</Button>
+      </form>
+      <form onSubmit={passwordForm.handleSubmit(onChangePassword)} className="space-y-4">
+        <div className="grid gap-2">
+          <Label htmlFor="old_password">Old Password</Label>
+          <PasswordInput id="old_password" {...passwordForm.register("old_password", { required: true })} />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor="new_password">New Password</Label>
+          <PasswordInput id="new_password" {...passwordForm.register("new_password", { required: true })} />
+        </div>
+        <Button type="submit">Change Password</Button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/routes/signup.tsx
+++ b/frontend/src/routes/signup.tsx
@@ -1,0 +1,47 @@
+import { createFileRoute, redirect, Link } from "@tanstack/react-router";
+import { useForm, type SubmitHandler } from "react-hook-form";
+import { SignupForm, type SignupFormData } from "@/components/signup-form";
+import useAuth, { isLoggedIn } from "@/hooks/use-auth";
+
+export const Route = createFileRoute("/signup")({
+  component: Signup,
+  beforeLoad: () => {
+    if (isLoggedIn()) {
+      throw redirect({ to: "/" });
+    }
+  },
+});
+
+function Signup() {
+  const { signupMutation, resetError } = useAuth();
+  const form = useForm<SignupFormData>({
+    defaultValues: {
+      username: "",
+      password: "",
+      name: "",
+      surname: "",
+      birthdate: "",
+      email: "",
+    },
+  });
+
+  const onSubmit: SubmitHandler<SignupFormData> = async (data) => {
+    resetError();
+    try {
+      await signupMutation.mutateAsync(data);
+    } catch {
+      // handled
+    }
+  };
+
+  return (
+    <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
+      <div className="w-full max-w-sm space-y-4">
+        <SignupForm form={form} onFormSubmit={onSubmit} />
+        <p className="text-center text-sm">
+          Already have an account? <Link to="/login" className="underline">Login</Link>
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add auth utils and models for user management
- implement account update and password change endpoints
- add signup, settings, and history pages on the frontend
- show login button or user menu in the header

## Testing
- `pre-commit run --files backend/earlycareers/api.py backend/earlycareers/crud.py backend/earlycareers/schemas.py frontend/src/components/header.tsx frontend/src/hooks/use-auth.ts frontend/src/routeTree.gen.ts frontend/src/routes/login.tsx frontend/src/components/signup-form.tsx frontend/src/components/user-menu.tsx frontend/src/routes/history.tsx frontend/src/routes/settings.tsx frontend/src/routes/signup.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68664e2951a48321887d0435a8d612dc