### PR TITLE
Add email notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ A collection of tech internships, new grads, research opportunities and more.
 ## Scraper
 [Check out the scraper repository](https://github.com/LorenzoLaCorte/internship-scraper)
 
+## Email notifications
+Save your search and receive the first five results every Monday directly in your inbox. Each email includes a link to view all results on the website and an unsubscribe link to stop notifications at any time. The backend automatically sends these summaries every Monday at 08:00 UTC.
+
 ## Internship Positions
 |company|title|location|link|
 |---|---|---|---|

--- a/backend/earlycareers/api.py
+++ b/backend/earlycareers/api.py
@@ -6,7 +6,11 @@ from fastapi import APIRouter, Query
 
 from earlycareers import crud
 from earlycareers.deps import SessionDep  # noqa: TC001
-from earlycareers.schemas import JobRead
+from earlycareers.schemas import (  # noqa: TC001
+    JobRead,
+    SubscriptionCreate,
+    SubscriptionRead,
+)
 
 if TYPE_CHECKING:
     from earlycareers.models import Job
@@ -50,3 +54,15 @@ def get_jobs_advanced(
         location=location,
         description=description,
     )
+
+
+@router.post("/subscriptions", response_model=SubscriptionRead, tags=["subscriptions"])
+def create_subscription(*, session: SessionDep, body: SubscriptionCreate) -> SubscriptionRead:
+    sub = crud.create_subscription(session=session, email=body.email, params=body.search_params)
+    return SubscriptionRead.model_validate(sub)
+
+
+@router.get("/subscriptions/unsubscribe/{token}", tags=["subscriptions"])
+def unsubscribe(*, session: SessionDep, token: str) -> bool:
+    crud.deactivate_subscription(session=session, token=token)
+    return True

--- a/backend/earlycareers/main.py
+++ b/backend/earlycareers/main.py
@@ -1,9 +1,11 @@
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.routing import APIRoute
 
 from earlycareers.api import router
 from earlycareers.core.config import settings
+from earlycareers.notifications import send_weekly_emails
 
 
 def custom_generate_unique_id(route: APIRoute) -> str:
@@ -17,6 +19,10 @@ app = FastAPI(
     redoc_url=f"{settings.API_STR}/redoc",
 )
 
+# schedule weekly notification emails at 08:00 UTC every Monday
+scheduler = AsyncIOScheduler(timezone="UTC")
+scheduler.add_job(send_weekly_emails, "cron", day_of_week="mon", hour=8, minute=0)
+
 if settings.all_cors_origins:
     app.add_middleware(
         CORSMiddleware,
@@ -28,6 +34,16 @@ if settings.all_cors_origins:
 
 
 app.include_router(router, prefix=settings.API_STR)
+
+
+@app.on_event("startup")
+async def start_scheduler() -> None:
+    scheduler.start()
+
+
+@app.on_event("shutdown")
+async def shutdown_scheduler() -> None:
+    scheduler.shutdown()
 
 
 if __name__ == "__main__":

--- a/backend/earlycareers/models.py
+++ b/backend/earlycareers/models.py
@@ -15,3 +15,13 @@ class JobBase(SQLModel):
 
 class Job(JobBase, table=True):
     __tablename__ = "jobs"  # pyright: ignore
+
+
+class SearchSubscription(SQLModel, table=True):
+    __tablename__ = "subscriptions"  # pyright: ignore
+
+    id: int | None = Field(default=None, primary_key=True)
+    email: str = Field(nullable=False, index=True)
+    search_json: str = Field(nullable=False, description="JSON encoded search parameters")
+    unsubscribe_token: str = Field(nullable=False, unique=True, index=True)
+    active: bool = Field(default=True)

--- a/backend/earlycareers/notifications.py
+++ b/backend/earlycareers/notifications.py
@@ -1,0 +1,58 @@
+import json
+import os
+import smtplib
+from email.message import EmailMessage
+from urllib.parse import urlencode
+
+from sqlmodel import Session
+
+from earlycareers import crud
+from earlycareers.core.database import engine
+
+WEBSITE_URL = os.environ.get("WEBSITE_URL", "http://localhost:5173")
+FROM_EMAIL = os.environ.get("FROM_EMAIL", "noreply@example.com")
+SMTP_HOST = os.environ.get("SMTP_HOST", "localhost")
+SMTP_PORT = int(os.environ.get("SMTP_PORT", "25"))
+SMTP_USER = os.environ.get("SMTP_USER")
+SMTP_PASS = os.environ.get("SMTP_PASS")
+
+
+def _send_email(to_addr: str, subject: str, body: str) -> None:
+    msg = EmailMessage()
+    msg["Subject"] = subject
+    msg["From"] = FROM_EMAIL
+    msg["To"] = to_addr
+    msg.set_content(body)
+
+    with smtplib.SMTP(SMTP_HOST, SMTP_PORT) as smtp:
+        if SMTP_USER and SMTP_PASS:
+            smtp.login(SMTP_USER, SMTP_PASS)
+        smtp.send_message(msg)
+
+
+def send_weekly_emails() -> None:
+    with Session(engine) as session:
+        subs = crud.get_active_subscriptions(session=session)
+        for sub in subs:
+            params = json.loads(sub.search_json)
+            jobs = crud.get_jobs(session=session, page=1, limit=5, search=params.get("q", ""))
+            if params.get("advanced"):
+                jobs = crud.get_jobs_advanced(
+                    session=session,
+                    page=1,
+                    limit=5,
+                    title=params.get("title", []),
+                    company=params.get("company", []),
+                    location=params.get("location", []),
+                    description=params.get("description", []),
+                )
+            lines = [f"{j.title} - {j.company} ({j.location})" for j in jobs]
+            results_text = "\n".join(lines) if lines else "No results found."
+            query = urlencode(params, doseq=True)
+            search_link = f"{WEBSITE_URL}/jobs?{query}"
+            unsubscribe_link = f"{WEBSITE_URL}/api/subscriptions/unsubscribe/{sub.unsubscribe_token}"
+            body = (
+                f"Here are the latest results for your saved search:\n\n{results_text}\n\n"
+                f"See all results: {search_link}\n\nUnsubscribe: {unsubscribe_link}\n"
+            )
+            _send_email(sub.email, "Your weekly internship results", body)

--- a/backend/earlycareers/schemas.py
+++ b/backend/earlycareers/schemas.py
@@ -1,4 +1,17 @@
+from sqlmodel import SQLModel
+
 from .models import JobBase
+
+
+class SubscriptionCreate(SQLModel):
+    email: str
+    search_params: dict
+
+
+class SubscriptionRead(SQLModel):
+    id: int
+    email: str
+    active: bool
 
 
 class JobRead(JobBase):

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "requests>=2.32.3",
     "sqlalchemy>=2.0.41",
     "sqlmodel>=0.0.24",
+    "apscheduler>=3.10.4",
 ]
 
 


### PR DESCRIPTION
## Summary
- add search subscription model and CRUD logic
- expose subscription create and unsubscribe endpoints
- add weekly email notification sender
- **schedule send_weekly_emails at 08:00 UTC every Monday**
- document the automatic schedule in README

## Testing
- `ruff check earlycareers`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6880e1daf3b48321a1416dbd7d8915fd